### PR TITLE
feat: remove skip tracing condition

### DIFF
--- a/extra/redisotel/tracing.go
+++ b/extra/redisotel/tracing.go
@@ -91,7 +91,7 @@ func newTracingHook(connString string, opts ...TracingOption) *tracingHook {
 
 func (th *tracingHook) DialHook(hook redis.DialHook) redis.DialHook {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
-		if !trace.SpanFromContext(ctx).IsRecording() {
+		if !trace.SpanContextFromContext(ctx).IsValid() {
 			return hook(ctx, network, addr)
 		}
 
@@ -109,7 +109,7 @@ func (th *tracingHook) DialHook(hook redis.DialHook) redis.DialHook {
 
 func (th *tracingHook) ProcessHook(hook redis.ProcessHook) redis.ProcessHook {
 	return func(ctx context.Context, cmd redis.Cmder) error {
-		if !trace.SpanFromContext(ctx).IsRecording() {
+		if !trace.SpanContextFromContext(ctx).IsValid() {
 			return hook(ctx, cmd)
 		}
 
@@ -145,7 +145,7 @@ func (th *tracingHook) ProcessPipelineHook(
 	hook redis.ProcessPipelineHook,
 ) redis.ProcessPipelineHook {
 	return func(ctx context.Context, cmds []redis.Cmder) error {
-		if !trace.SpanFromContext(ctx).IsRecording() {
+		if !trace.SpanContextFromContext(ctx).IsValid() {
 			return hook(ctx, cmds)
 		}
 


### PR DESCRIPTION
`go-redis` 在生成 trace span 前会先判断 `trace.SpanFromContext(ctx).IsRecording()` 看当前 context 是否有正在处理中的 parent span 但这和 istio 的使用场景冲突（即 redis 的 parent span 由 sidecar 处理并不会直接传入 context）因此改成只对 context 中的 traceID 进行有效性判断